### PR TITLE
opcnifi-46 - Update code for latest UA Stack

### DIFF
--- a/nifi-opcua-bundle/nifi-opcua-service/src/main/java/com/hashmapinc/tempus/processors/StandardOPCUAService.java
+++ b/nifi-opcua-bundle/nifi-opcua-service/src/main/java/com/hashmapinc/tempus/processors/StandardOPCUAService.java
@@ -317,7 +317,7 @@ public class StandardOPCUAService extends AbstractControllerService implements O
             // Describe end point
             endpointDescription = new EndpointDescription();
             endpointDescription.setEndpointUrl(context.getProperty(ENDPOINT).getValue());
-            endpointDescription.setServerCertificate(myOwnCert.getEncoded());
+            endpointDescription.setServerCertificate(ByteString.valueOf(myOwnCert.getEncoded()));
             endpointDescription.setSecurityMode(MessageSecurityMode.Sign);
 
             switch (context.getProperty(SECURITY_POLICY).getValue()) {

--- a/nifi-opcua-bundle/nifi-opcua-service/src/test/java/com/hashmapinc/tempus/processors/nifi_opcua_services/TestStandardOPCUAService.java
+++ b/nifi-opcua-bundle/nifi-opcua-service/src/test/java/com/hashmapinc/tempus/processors/nifi_opcua_services/TestStandardOPCUAService.java
@@ -42,7 +42,7 @@ public class TestStandardOPCUAService {
     @Before
     public void init() {
         try {
-            server = new TestServer(45678);
+            server = new TestServer(45678, "user", "test");
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <properties>
         <jdk.version>1.8</jdk.version>
-        <opc-ua-stack.version>1.03.341.0-SNAPSHOT</opc-ua-stack.version>
+        <opc-ua-stack.version>1.03.342.1-SNAPSHOT</opc-ua-stack.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This PR addresses an issue where the OPC UA stack was updated (1.03.342.1) to accept a ByteString (the OPC type) for a certificate rather than a byte[].