### PR TITLE
Add max_recursivedepth as an attribute to the flowfile in GetOPCNodeList processor

### DIFF
--- a/nifi-opcua-bundle/nifi-opcua-bundle-processors/src/main/java/com/hashmapinc/tempus/processors/GetOPCNodeList.java
+++ b/nifi-opcua-bundle/nifi-opcua-bundle-processors/src/main/java/com/hashmapinc/tempus/processors/GetOPCNodeList.java
@@ -189,6 +189,7 @@ public class GetOPCNodeList extends AbstractProcessor {
 
 				if (flowFile != null) {
 					try {
+						flowFile = session.putAttribute(flowFile, "recursiveDepth", Integer.toString(max_recursiveDepth));
 						flowFile = session.write(flowFile, new OutputStreamCallback() {
 							public void process(OutputStream out) throws IOException {
 

--- a/nifi-opcua-bundle/nifi-opcua-bundle-processors/src/main/java/com/hashmapinc/tempus/processors/GetOPCNodeList.java
+++ b/nifi-opcua-bundle/nifi-opcua-bundle-processors/src/main/java/com/hashmapinc/tempus/processors/GetOPCNodeList.java
@@ -190,6 +190,7 @@ public class GetOPCNodeList extends AbstractProcessor {
 				if (flowFile != null) {
 					try {
 						flowFile = session.putAttribute(flowFile, "recursiveDepth", Integer.toString(max_recursiveDepth));
+						flowFile = session.putAttribute(flowFile, "startNode", starting_node);
 						flowFile = session.write(flowFile, new OutputStreamCallback() {
 							public void process(OutputStream out) throws IOException {
 

--- a/nifi-opcua-bundle/nifi-opcua-bundle-processors/src/main/java/com/hashmapinc/tempus/processors/GetOPCNodeList.java
+++ b/nifi-opcua-bundle/nifi-opcua-bundle-processors/src/main/java/com/hashmapinc/tempus/processors/GetOPCNodeList.java
@@ -42,7 +42,7 @@ import org.opcfoundation.ua.core.Identifiers;
 
 public class GetOPCNodeList extends AbstractProcessor {
 
-	private String starting_node = null;
+	private String node_filter = null;
 	private String print_indentation = "No";
 	private String remove_opc_string = "No";
 	private Integer max_recursiveDepth;
@@ -55,9 +55,9 @@ public class GetOPCNodeList extends AbstractProcessor {
 			.identifiesControllerService(OPCUAService.class)
 			.build();
 
-	public static final PropertyDescriptor STARTING_NODE = new PropertyDescriptor
-			.Builder().name("Starting Nodes")
-			.description("Provide regular expression for nodes you want to fetch data. Default it will fetch data for all nodes starting from root node. Separate multiple regex with a pipe(|)")
+	public static final PropertyDescriptor NODE_FILTER = new PropertyDescriptor
+			.Builder().name("Node Filter")
+			.description("Provide regular expression for nodes you want to fetch node-list. Default it will fetch node-list for all nodes starting from root node. Separate multiple regex with a pipe(|)")
 			.addValidator(StandardValidators.REGULAR_EXPRESSION_VALIDATOR)
 			.build();
 
@@ -114,7 +114,7 @@ public class GetOPCNodeList extends AbstractProcessor {
 		final List<PropertyDescriptor> descriptors = new ArrayList<PropertyDescriptor>();
 		descriptors.add(OPCUA_SERVICE);
 		descriptors.add(RECURSIVE_DEPTH);
-		descriptors.add(STARTING_NODE);
+		descriptors.add(NODE_FILTER);
 		descriptors.add(PRINT_INDENTATION);
 		descriptors.add(REMOVE_OPC_STRING);
 		descriptors.add(MAX_REFERENCE_PER_NODE);
@@ -142,7 +142,7 @@ public class GetOPCNodeList extends AbstractProcessor {
 
 		print_indentation = context.getProperty(PRINT_INDENTATION).getValue();
 		max_recursiveDepth = Integer.valueOf(context.getProperty(RECURSIVE_DEPTH).getValue());
-		starting_node = context.getProperty(STARTING_NODE).getValue();
+		node_filter = context.getProperty(NODE_FILTER).getValue();
 		remove_opc_string = context.getProperty(REMOVE_OPC_STRING).getValue();
 		max_reference_per_node = Integer.valueOf(context.getProperty(MAX_REFERENCE_PER_NODE).getValue());
 	}
@@ -168,10 +168,10 @@ public class GetOPCNodeList extends AbstractProcessor {
 			}
 
 			Pattern pattern;
-			if (starting_node == null) {
+			if (node_filter == null) {
 				pattern = Pattern.compile("[^\\.].*");
 			} else {
-				pattern = Pattern.compile(starting_node);
+				pattern = Pattern.compile(node_filter);
 			}
 
 			String nameSpace = opcUAService.getNameSpace(print_indentation, max_recursiveDepth, pattern, new UnsignedInteger(max_reference_per_node));
@@ -184,7 +184,7 @@ public class GetOPCNodeList extends AbstractProcessor {
 				if (flowFile != null) {
 					try {
 						flowFile = session.putAttribute(flowFile, "recursiveDepth", Integer.toString(max_recursiveDepth));
-						flowFile = session.putAttribute(flowFile, "startNode", starting_node);
+						flowFile = session.putAttribute(flowFile, "nodeFilter", node_filter);
 						flowFile = session.write(flowFile, new OutputStreamCallback() {
 							public void process(OutputStream out) throws IOException {
 

--- a/nifi-opcua-bundle/nifi-opcua-service-api/src/main/java/com/hashmapinc/tempus/processors/OPCUAService.java
+++ b/nifi-opcua-bundle/nifi-opcua-service-api/src/main/java/com/hashmapinc/tempus/processors/OPCUAService.java
@@ -23,6 +23,7 @@ import org.apache.nifi.processor.exception.ProcessException;
 import org.opcfoundation.ua.builtintypes.ExpandedNodeId;
 import org.opcfoundation.ua.builtintypes.UnsignedInteger;
 import java.util.List;
+import java.util.regex.Pattern;
 
 @Tags({"OPC Service API"})
 @CapabilityDescription("Provides client API for working with OPC servers")
@@ -30,7 +31,7 @@ public interface OPCUAService extends ControllerService {
 
 	byte[] getValue(List<String> reqTagname, String returnTimestamp, String excludeNullValue, String nullValueString, String dataFormat, boolean longTimestamp) throws ProcessException;
 	
-	String getNameSpace(String print_indentation, int max_recursiveDepth, List<ExpandedNodeId> expandedNodeIds, UnsignedInteger max_reference_per_node)
+	String getNameSpace(String print_indentation, int max_recursiveDepth, Pattern pattern, UnsignedInteger max_reference_per_node)
 			throws ProcessException;
 
 	boolean updateSession();

--- a/nifi-opcua-bundle/nifi-opcua-service/src/test/java/com/hashmapinc/tempus/processors/nifi_opcua_services/TestStandardOPCUAService.java
+++ b/nifi-opcua-bundle/nifi-opcua-service/src/test/java/com/hashmapinc/tempus/processors/nifi_opcua_services/TestStandardOPCUAService.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public class TestStandardOPCUAService {
 
@@ -75,7 +76,8 @@ public class TestStandardOPCUAService {
         runner.enableControllerService(service);
         List<ExpandedNodeId> ids = new ArrayList<>();
         ids.add(new ExpandedNodeId((Identifiers.RootFolder)));
-        stringBuilder.append(service.getNameSpace("No", 3, ids, new UnsignedInteger(1000)));
+        Pattern pattern = Pattern.compile("[^\\.].*");
+        stringBuilder.append(service.getNameSpace("No", 3, pattern, new UnsignedInteger(1000)));
 
         String result = stringBuilder.toString();
 
@@ -103,7 +105,8 @@ public class TestStandardOPCUAService {
         runner.enableControllerService(service);
         List<ExpandedNodeId> ids = new ArrayList<>();
         ids.add(new ExpandedNodeId((Identifiers.RootFolder)));
-        stringBuilder.append(service.getNameSpace("No", 3, ids, new UnsignedInteger(1000)));
+        Pattern pattern = Pattern.compile("[^\\.].*");
+        stringBuilder.append(service.getNameSpace("No", 3, pattern, new UnsignedInteger(1000)));
 
         String result = stringBuilder.toString();
 


### PR DESCRIPTION
1. Change to add max_recursive depth as a flowfile attribute.
2. Added change for adding starting node to flowfile attribute.
3. Changes for supporting regex support for starting node property in GetOPCNodeList processor. The approach is to search all node starting from root node and compare it with regex.